### PR TITLE
Deflaked CI jobs. Uploading server logs as workflow artifact

### DIFF
--- a/.github/workflows/yarn-test-lint.yml
+++ b/.github/workflows/yarn-test-lint.yml
@@ -40,6 +40,7 @@ jobs:
 
     - name: Upload test logs
       uses: actions/upload-artifact@v2
+      if: ${{ always() }}
       with:
         name: test-server_logs
         path: server/logs

--- a/.github/workflows/yarn-test-lint.yml
+++ b/.github/workflows/yarn-test-lint.yml
@@ -37,3 +37,9 @@ jobs:
       run: yarn run test
     - name: yarn run lint
       run: yarn run lint
+
+    - name: Upload test logs
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-server_logs
+        path: server/logs

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -14,7 +14,7 @@ function enginePatch(cconfig: ScreepsConfig): void {
 
       // Subscribe to requests for tick
       pubsub.subscribe(pubsub.keys.LOCKSTEP_UNLOCK, async (ticks: number) => {
-        console.log(`lockstep: unlocked for ${ticks} ticks`);
+        // console.log(`lockstep: unlocked for ${ticks} ticks`);
         await env.set(env.keys.LOCKSTEP_COUNT, ticks);
       });
 
@@ -22,9 +22,8 @@ function enginePatch(cconfig: ScreepsConfig): void {
       const oldNotifyTickStarted = driver.notifyTickStarted;
       driver.notifyTickStarted = () => {
         return oldNotifyTickStarted().then(async () => {
-          console.log('lockstep:notifyTickStarted');
+          // console.log('lockstep:notifyTickStarted');
           const lockstep = await env.get(env.keys.LOCKSTEP_COUNT);
-          console.log(`lockstep = ${lockstep}`);
 
           if (lockstep != undefined && lockstep != null && lockstep <= 0) {
             // Simulate a 'paused' error, special cased in engine/main

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -14,6 +14,7 @@ function enginePatch(cconfig: ScreepsConfig): void {
 
       // Subscribe to requests for tick
       pubsub.subscribe(pubsub.keys.LOCKSTEP_UNLOCK, async (ticks: number) => {
+        console.log(`lockstep: unlocked for ${ticks} ticks`);
         await env.set(env.keys.LOCKSTEP_COUNT, ticks);
       });
 
@@ -21,8 +22,9 @@ function enginePatch(cconfig: ScreepsConfig): void {
       const oldNotifyTickStarted = driver.notifyTickStarted;
       driver.notifyTickStarted = () => {
         return oldNotifyTickStarted().then(async () => {
-          // console.log('lockstep:notifyTickStarted');
+          console.log('lockstep:notifyTickStarted');
           const lockstep = await env.get(env.keys.LOCKSTEP_COUNT);
+          console.log(`lockstep = ${lockstep}`);
 
           if (lockstep != undefined && lockstep != null && lockstep <= 0) {
             // Simulate a 'paused' error, special cased in engine/main

--- a/src/mod.spec.ts
+++ b/src/mod.spec.ts
@@ -7,8 +7,11 @@ import {
   LOCKSTEP_UNLOCK,
 } from './constants';
 
-/** Sleep for m milliseconds */
-const sleep = (m: number) => new Promise(r => setTimeout(r, m))
+/**
+ * Sleep for m milliseconds
+ * https://stackoverflow.com/a/48882182
+ */
+const sleep = (m: number) => new Promise((r) => setTimeout(r, m));
 
 describe('ScreepsMod Lockstep', () => {
   let server: ScreepsTestServer|undefined;

--- a/src/mod.spec.ts
+++ b/src/mod.spec.ts
@@ -7,6 +7,9 @@ import {
   LOCKSTEP_UNLOCK,
 } from './constants';
 
+/** Sleep for m milliseconds */
+const sleep = (m: number) => new Promise(r => setTimeout(r, m))
+
 describe('ScreepsMod Lockstep', () => {
   let server: ScreepsTestServer|undefined;
   /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -26,7 +29,7 @@ describe('ScreepsMod Lockstep', () => {
     await server.start();
     console.log('setting tick rate to 100');
     pubsub.publish('setTickRate', 100);  // 10 ticks per sec
-    jest.runAllTimers();
+    await sleep(100);
   });
 
   afterEach(async () => {
@@ -42,10 +45,8 @@ describe('ScreepsMod Lockstep', () => {
 
   it('should progress two ticks when unlocked for two ticks', async () => {
     const startTime = await env.get(env.keys.GAMETIME);
-    const defer = q.defer<number>();
-    pubsub.subscribe(LOCKSTEP_LOCKED, (gameTime: number) => {
-      defer.resolve(gameTime);
-    });
+    const defer = q.defer();
+    pubsub.subscribe(LOCKSTEP_LOCKED, () => defer.resolve());
 
     pubsub.publish(LOCKSTEP_UNLOCK, 2);
     await defer.promise;

--- a/src/mod.spec.ts
+++ b/src/mod.spec.ts
@@ -28,9 +28,7 @@ describe('ScreepsMod Lockstep', () => {
       steamApiKey: process.env.STEAM_API_KEY || '',
     });
     ({env, pubsub} = server);
-    console.log('starting server');
     await server.start();
-    console.log('setting tick rate to 100');
     pubsub.publish('setTickRate', 100);  // 10 ticks per sec
     await sleep(100);
   });

--- a/src/mod.spec.ts
+++ b/src/mod.spec.ts
@@ -22,13 +22,15 @@ describe('ScreepsMod Lockstep', () => {
       steamApiKey: process.env.STEAM_API_KEY || '',
     });
     ({env, pubsub} = server);
+    console.log('starting server');
     await server.start();
+    console.log('setting tick rate to 100');
     pubsub.publish('setTickRate', 100);  // 10 ticks per sec
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     if (server) {
-      server.stop();
+      await server.stop();
     }
     server = env = pubsub = undefined;
   });

--- a/src/mod.spec.ts
+++ b/src/mod.spec.ts
@@ -58,7 +58,7 @@ describe('ScreepsMod Lockstep', () => {
        const startTime = await env.get(env.keys.GAMETIME);
        pubsub.publish(LOCKSTEP_UNLOCK, 2);
 
-       const defer = q.defer();
+       const defer = q.defer<number>();
        pubsub.subscribe(
            LOCKSTEP_LOCKED,
            (gameTime: number) => defer.resolve(gameTime),


### PR DESCRIPTION
Fixed flakiness in the CI tests.

Specifically needed to await `server.stop()` in the AfterEach so that the server was closed correctly.
To help debugging, uploading `server/logs` as a Workflow Artifact even if the tests fail. Very useful for inspecting failures

Minor formatting fixes.